### PR TITLE
Corrections for HOEB solver

### DIFF
--- a/example/DomainDecomposition/common/EBPetscSolver.H
+++ b/example/DomainDecomposition/common/EBPetscSolver.H
@@ -56,6 +56,7 @@ public:
     m_dx           =    a_dx;
     m_alpha        =    a_alpha;
     m_beta         =    a_beta;
+    m_nz_init_guess = true;
     m_prestring[0] = '\0';
     for(int iface = 0; iface < 2*DIM; iface++)
     {
@@ -68,6 +69,12 @@ public:
 
     m_kappa.define(m_grids, m_ivghost, m_graphs);
     m_inhoContr.define(m_grids, m_ivghost, m_graphs);
+    Chombo4::DataIterator dit = m_grids.dataIterator();
+    for(int ibox = 0; ibox < dit.size(); ++ibox)
+      {
+        auto& inhofab = m_inhoContr[dit[ibox]];
+        inhofab.setVal(0.0);
+      }
     m_diagW.define(m_grids, m_ivghost, m_graphs);
 
     m_exchangeCopier.exchangeDefine(m_grids, m_ivghost);
@@ -156,7 +163,7 @@ public:
   //need the inhomogeoneous contribution in a data holder 
   void
   fillInhoContr(const vector<double>   & a_inhoContr,
-		const vector< EBIndex<CELL> > & a_dstVoFs,
+                const vector< EBIndex<CELL> > & a_dstVoFs,
                 const Chombo4::DataIndex & a_dit)
   {
     using Chombo4::DataIterator;
@@ -176,7 +183,7 @@ public:
       auto pt     =   a_dstVoFs[ivof].m_pt;
       if(graph.isRegular(pt))
       {
-        reghost(pt, 0) = a_inhoContr[ivof];
+        reghost(pt, 0) = m_beta*a_inhoContr[ivof];
       }
       else if(graph.isCovered(pt))
       {
@@ -184,8 +191,8 @@ public:
       }
       else
       {
-        reghost(pt  , 0) = a_inhoContr[ivof];
-        irrhost(vof , 0) = a_inhoContr[ivof];
+        reghost(pt  , 0) = m_beta*a_inhoContr[ivof];
+        irrhost(vof , 0) = m_beta*a_inhoContr[ivof];
       }
     }
     // now copy to the device
@@ -193,6 +200,12 @@ public:
   
     m_inhoContr.exchange(m_exchangeCopier);
   }
+
+  Real getAlpha()
+    {return m_alpha;}
+
+  Real getBeta()
+    {return m_beta;}
 
   EBLevelBoxData<CELL, 1> & getKappa()
   {
@@ -235,7 +248,7 @@ public:
   void
   applyOp(EBLevelBoxData<CELL, 1>       & a_lph,
           const EBLevelBoxData<CELL, 1> & a_phi,
-          bool a_doExchange) const
+          bool a_doExchange = true) const
   
   {
     using Chombo4::DataIterator;
@@ -260,14 +273,14 @@ public:
       //set lphi = kappa* div(F)
       stencil->apply(lphfab, phifab,  true, 1.0);
       //this adds kappa*alpha*phi (making lphi = kappa*alpha*phi + kappa*beta*divF)
-      Chombo4::Box grid =m_grids[dit[ibox]];
+      Chombo4::Box grid = m_grids[dit[ibox]];
       Bx  grbx = getProtoBox(grid);
       auto& kapfab = m_kappa[dit[ibox]];
   
       //pout() << "going into add alphaphi" << endl;
       Bx inputBox = lphfab.inputBox();
       ebforall(inputBox, addAlphaPhi, grbx, lphfab, phifab, kapfab, m_alpha, m_beta);
-      lphfab += inhofab; 
+      lphfab += inhofab;
       ideb++;
     }
   }
@@ -525,7 +538,7 @@ private:
   
   virtual PetscInt formMatrix()
   {
-    
+    CH_TIME("EBPetscSolver::formMatrix");
     {
       using Chombo4::DataIterator;
       char str[256];
@@ -582,6 +595,7 @@ private:
         {
           auto vof    =   dstVoFs[ivof];
           auto& stenc =  wstencil[ivof];
+          const Real kappa  = m_kappa[dit[ibox]](vof, 0);
           int irow = m_gids[dit[ibox]](vof, 0); 
           for(int ivof = 0; ivof < stenc.size(); ivof++)
           {
@@ -590,7 +604,7 @@ private:
             Real weight = m_beta*stenwgt;
             if(stenvof == vof)
             {
-              weight += m_alpha;
+              weight += kappa*m_alpha;
             }
             int icol = m_gids[dit[ibox]](stenvof, 0);  
             PetscInt irowpet = irow;
@@ -613,6 +627,7 @@ private:
   }
   virtual PetscInt setupSolver()
   {
+    CH_TIME("EBPetscSolver::setupSolver");
     // create solvers
     PetscBool ism = PETSC_FALSE;
 #if PETSC_VERSION_GE(3,7,0)

--- a/src/EBProto/Proto_EBExactSolutions.H
+++ b/src/EBProto/Proto_EBExactSolutions.H
@@ -26,7 +26,8 @@ public:
   Real operator()(const EBGraph & a_graph,
                   const Real    & a_dx,
                   const VoluData& a_voldat,
-                  const EBIndex<CELL>   & a_vof)
+                  const EBIndex<CELL>   & a_vof,
+                  const IvDIM & a_baseDeriv = IvDIM::Zero)
   {
     Real retval = 0;
     RealVect centloc;
@@ -53,12 +54,17 @@ public:
     for(MomentIterator<DIM, order> momit; momit.ok(); ++momit)
     {
       IvDIM  power = momit();
-      Real   deriv = getDerivative(power, centloc);
-      int   idenom = (power.factorial());
-      Real   denom = (Real)(idenom);
-      Real   momen = moments[power];
-      Real   incre = deriv*momen/denom;
-      retval += incre;
+      IvDIM  derivPower = power + a_baseDeriv;
+      // higher derivatives are not supported, but solutions still should be globally 4th order
+      if (derivPower.sum() <= 4)
+        {
+          Real   deriv = getDerivative(derivPower, centloc);
+          int   idenom = (power.factorial());
+          Real   denom = (Real)(idenom);
+          Real   momen = moments[power];
+          Real   incre = deriv*momen/denom;
+          retval += incre;
+        }
     }
     Real minvol = 1.0e-16;
     if(volu > minvol)
@@ -112,8 +118,8 @@ public:
   virtual Real getDerivative(IvDIM    a_deriv,
                              RealVect a_loc)
   {
-    Real x = a_loc[0];
-    Real y = a_loc[1];
+    Real x = a_loc[0] - m_center;
+    Real y = a_loc[1] - m_center;
     Real x2 = x*x;
     Real x3 = x*x*x;
     Real x4 = x*x*x*x;
@@ -128,7 +134,7 @@ public:
     Real r02 = m_radius*m_radius;
     Real z2 = 0;
 #if DIM==3
-    Real z = a_loc[2];
+    Real z = a_loc[2] - m_center;
     z2 = z*z;
     Real z3 = z*z*z;
     Real z4 = z*z*z*z;
@@ -776,12 +782,13 @@ public:
       retval = 0;
     }
 
-    Real tol = 1.0e-16;
+    Real tol = 1.0e-13;
     Real diff = std::abs(retval - retval_simp);
     if(diff > tol)
-    {
-      Chombo4::MayDay::Error("broken elegance");
-    }
+      {
+        pout() << diff << std::endl;
+        Chombo4::MayDay::Error("broken elegance");
+      }
     return retval_simp;
   }
   virtual ~MonomialEF()

--- a/src/EBProto/hoeb/Proto_WLSCell.H
+++ b/src/EBProto/hoeb/Proto_WLSCell.H
@@ -632,6 +632,16 @@ namespace Proto
         if (a_exactSolFun == 2) m_exactSol = shared_ptr<BaseExactSolution<order> >(new OneDimCosProduct<order>(amplitude,frequency,center));
         if (a_exactSolFun == 3) m_exactSol = shared_ptr<BaseExactSolution<order> >(new OneDimSinProduct<order>(amplitude,frequency,center));
       }
+      else if (a_exactSolFun == 4)
+        {
+          Real rad;
+          pp.get("phi_rad", rad);
+          Real cen;
+          pp.get("phi_cen", cen);
+
+          m_exactSol = shared_ptr<BaseExactSolution<order> >(new SineSphereEF<order>(rad, cen));
+
+        }
     }
 
     //Radius needed for neighbors list around a face (Manhattan style)

--- a/src/EBTools/Chombo_EBLevelBoxData.H
+++ b/src/EBTools/Chombo_EBLevelBoxData.H
@@ -321,6 +321,12 @@ public:
     writeToFileHDF5(filename, coveredValue);
   }
 
+  void dumpFile(std::string fileName, Real coveredValue) const
+  {
+    string filename = fileName+".hdf5";
+    writeToFileHDF5(filename, coveredValue);
+  }
+
   /// This is for plotfiles only  as multivalued stuff will be lost.
   static 
   void copyHostToFAB(LevelData<FArrayBox>                               & a_fabxDat,


### PR DESCRIPTION
The primary change here is fixing the EBPetscSolver to correctly apply kappa weighting for the alpha term, and correctly scale the inhomogeneous terms by beta. With these changes, a 4th order heat equation solver is possible, as shown in the HOEB code.

There are also some additions to the EBExactSolutions to allow for evaluating cell averaged derivatives, which should have no change to existing usage.